### PR TITLE
Don't warn that a field is missing if the user requested its omission

### DIFF
--- a/bin/prebib
+++ b/bin/prebib
@@ -168,7 +168,8 @@ class PreBib:
             warn_missing_entry = []
 
         warn_missing = [ k for
-                k in warn_missing_entry if k not in data.keys() ]
+                        k in warn_missing_entry if k not in data.keys()
+                        and k not in self.extra_excludes]
         for i in warn_missing:
             self.msg("Entry '%s' is missing a '%s' field" % (key, i))
 


### PR DESCRIPTION
Currently you can run prebib with `-x month` and then have it complain that the month field is missing. This fixes that class of warning.