### PR TITLE
Check years in keys are not in four-digit format.

### DIFF
--- a/bin/prebib
+++ b/bin/prebib
@@ -55,7 +55,8 @@ REGEX_WARNINGS = {
         # Authors should just list the title of the conference/workshop.
         ".*[Pp]roc\.", ".*[Pp]roceedings", ".*[Ww]orkshop"
     ],
-    "author" : [".*[Ee]dward [Bb]arrett"] # Prefer "Edd"
+    "author" : [".*[Ee]dward [Bb]arrett"], # Prefer "Edd"
+    "id": [r"^\w+\d\d\d\d"], # Years in keys should be in two-digit format.
 }
 
 ALWAYS_WARN_IF_MISSING = [ "year", "author", "title" ]
@@ -150,6 +151,7 @@ class PreBib:
 
     def regex_warn(self, key, data):
         """ Warn about common errors that can be detected by regex """
+
         for (f, v) in data.items():
             if f == "author": # library splits authors
                 v = u"and".join([ u" ".join(x) for x in v])

--- a/bin/prebib
+++ b/bin/prebib
@@ -149,7 +149,7 @@ class PreBib:
         return filtered_data
 
     def regex_warn(self, key, data):
-        """ Warn about common error that can be detected by regex """
+        """ Warn about common errors that can be detected by regex """
         for (f, v) in data.items():
             if f == "author": # library splits authors
                 v = u"and".join([ u" ".join(x) for x in v])

--- a/softdev.bib
+++ b/softdev.bib
@@ -944,7 +944,7 @@ month hence the empty month field.
     address = {New York, NY, USA},
 }
 
-@inproceedings{grimmer2014dynamically,
+@inproceedings{grimmer14dynamically,
     author = {Mathias Grimmer and Chris Seaton and Thomas W\"urthinger and Hanspeter M\"ossenb\"ock},
     title = "Dynamically Composing Languages in a Modular Way: Supporting {C} Extensions for Dynamic Languages",
     booktitle = "Modularity",
@@ -1284,7 +1284,7 @@ month hence the empty month field.
 }
 
 
-@inproceedings{sullivan_dynamic_2001,
+@inproceedings{sullivan01dynamic,
     title = {Dynamic {Partial} {Evaluation}},
     isbn = {3-540-42068-1},
     booktitle = {PADO},
@@ -1606,7 +1606,7 @@ month hence the empty month field.
     author = {Google},
 }
 
-@Book{tukey1977exploratory,
+@Book{tukey77exploratory,
     Title  = {Exploratory Data Analysis},
     Author = {John Tukey},
     Year   = {1977},
@@ -2660,7 +2660,7 @@ month hence the empty month field.
     pages = 379–393,
 }
 
-@inproceedings{xia19cherivoke,
+@inproceedings{xia29cherivoke,
   author = "Xia, Hongyan and Woodruff, Jonathan and Ainsworth, Sam and
     Filardo, Nathaniel W. and Roe, Michael and Richardson, Alexander and
     Rugg, Peter and Neumann, Peter G. and Moore, Simon W. and


### PR DESCRIPTION
I had planned to check for all keys not matching the format `authorYYtitle`, but there are some keys which have no year or author whatsoever, e.g. `@misc{tickless, ...}`.

I've fixed the offending keys, but should I bother to go in search of broken consumers?