### PR TITLE
Add JVM article on premature finalisation

### DIFF
--- a/softdev.bib
+++ b/softdev.bib
@@ -3405,3 +3405,12 @@ month hence the empty month field.
     howpublished = {\url{https://llvm.org/docs/GarbageCollection.html}},
     note = {Accessed: 2023-04-03},
 }
+
+@misc{shipilev20local,
+    title = "{JVM} Anatomy Quark \#8: Local Variable Reachability",
+    author = "Alekesy Shipilëv",
+    year = 2020,
+    month = Jul,
+    howpublished = {\url{https://shipilev.net/jvm/anatomy-quarks/8-local-var-reachability/}},
+    note = {Accessed: 2024-10-08},
+}


### PR DESCRIPTION
Turns out this is still a real problem in Java.

They provide a method (like C#'s keepAlive API) for telling the collector that an object is still reachable by the mutator [1].

[1] https://docs.oracle.com/javase/9/docs/api/java/lang/ref/Reference.html#reachabilityFence-java.lang.Object-