### PR TITLE
Fix rustlangref.

### DIFF
--- a/softdev.bib
+++ b/softdev.bib
@@ -3389,12 +3389,12 @@ month hence the empty month field.
 }
 
 @misc{rustlangref,
-    title = "The {Rust} language reference}",
+    title = "The {Rust} language reference",
+    author = "The Rust Developers",
     howpublished = {\url{https://doc.rust-lang.org/reference/}},
     note = {Accessed: 2024-10-01},
     year = 2014,
     month = Sep,
-    author = {The Rust Developers},
 }
 
 @misc{llvm14statepoints,


### PR DESCRIPTION
Note the incorrect trailing `}` in the `title` field.